### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,5 +12,6 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "674dc25c79b53f0cbf4b34df"
+  "nxCloudId": "674f201cd65714bfee93e42e",
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://staging.nx.app/orgs/674dc50f2be77991fb50c5ce/workspaces/674f201cd65714bfee93e42e

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.